### PR TITLE
fix: Redirect home to any page after loading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,18 +19,25 @@ import PerticipentStaff from "./pages/work/perticipent-staff/PerticipentStaff";
 
 // Private Route
 const PrivateRoute = () => {
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, loading } = useAuth();
+
+  if (loading) {
+    return null;
+  }
+
   return isLoggedIn ? <Outlet /> : <Navigate to="/login" replace />;
 };
 
 function App() {
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, loading } = useAuth();
   return (
     <Routes>
       {/* Public Route */}
       <Route
         path="/login"
-        element={isLoggedIn ? <Navigate to="/" replace /> : <Login />}
+        element={
+          isLoggedIn && !loading ? <Navigate to="/" replace /> : <Login />
+        }
       />
 
       {/* Private Routes */}


### PR DESCRIPTION
- Problem: When users reload their page, they are redirected to the home page. 
- Solution: Now they can remain on their current page upon reloading.